### PR TITLE
[FIX] Typo dans l'exemple V 03

### DIFF
--- a/exemples/05-acces-au-materiel/example-V-03.c
+++ b/exemples/05-acces-au-materiel/example-V-03.c
@@ -27,7 +27,7 @@ static int __init example_init(void)
 	if (err != 0)
 		return err;
 
-	err = gpio_request(EXAMPLE_GPIO_OUT, THIS_MODULE->name)
+	err = gpio_request(EXAMPLE_GPIO_OUT, THIS_MODULE->name);
 	if (err != 0) {
 		gpio_free(EXAMPLE_GPIO_IN);
 		return err;


### PR DESCRIPTION
Un certain nombre d'exemples de la partie V ne compilent plus (sur un noyau 5.4.0 du moins), en particulier le n°3 à cause d'un oubli de `;`